### PR TITLE
Adds volume labels to work with SELinux

### DIFF
--- a/tutorial.sh
+++ b/tutorial.sh
@@ -83,7 +83,7 @@ function runTutorialContainer() {
     fi
     killContainerIfExists ansible.tutorial > /dev/null
     echo "starting container ansible.tutorial"
-    docker run -it -v "${WORKSPACE}":/root/workspace -v "${TUTORIALS_FOLDER}":/tutorials --net ${NETWORK_NAME} \
+    docker run -it -v "${WORKSPACE}":/root/workspace:Z -v "${TUTORIALS_FOLDER}":/tutorials:Z --net ${NETWORK_NAME} \
       --env HOSTPORT_BASE=$HOSTPORT_BASE \
       ${entrypoint} --name="ansible.tutorial" "${TUTORIAL_IMAGE}" ${args}
     return $?


### PR DESCRIPTION
When trying to use the tutorials on a system running SELinux, the
lack of volume labels causes an avc error and the tutorial files
are not readable resulting in a menu with no options.

This patch adds the Z option to the mount labels, telling Docker
to label the content with a private unshared label.