### PR TITLE
Add matching code format to hostname

### DIFF
--- a/tutorials/11-step-11.nutsh
+++ b/tutorials/11-step-11.nutsh
@@ -56,7 +56,7 @@ prompt {
 
 "Hosts vars follow exactly the same rules, but live in files under `host_vars` directory."
 
-"Let's define weights for our backends in host_vars/host1.example.com:"
+"Let's define weights for our backends in `host_vars/host1.example.com:`"
 
 print("\t
 haproxy_backend_weight: 100\n\t


### PR DESCRIPTION
Just a small fix to make the formatting consistent. 

<img width="1330" alt="Screen Shot 2019-05-15 at 5 38 02 PM" src="https://user-images.githubusercontent.com/3988879/57816351-399d6100-7738-11e9-8c3c-70770eae08b5.png">
