### PR TITLE
Fix: link in lesson 14 issue #30

### DIFF
--- a/tutorials/13-step-13.nutsh
+++ b/tutorials/13-step-13.nutsh
@@ -7,7 +7,7 @@ run(`cp -r /tutorials/files/step-13/* .`)
 
 "In this lesson, we are going to use a role from Ansible Galaxy to install Jenkins on one of our nodes."
 
-"You can browse available roles here: `https://galaxy.ansible.com/list#/roles`"
+"You can browse available roles here: https://galaxy.ansible.com/search?keywords=&order_by=-relevance&deprecated=false&type=role&page=1"
 
 "Run the following command to install the required role"
 


### PR DESCRIPTION
This link takes you to a search resultspage with all roles that are not marked as deprecated.
the old link lead to a not existing site